### PR TITLE
인벤토리 출력창 일부 수정, 아이템 이름 간격 조정

### DIFF
--- a/Inventory.cs
+++ b/Inventory.cs
@@ -17,8 +17,9 @@ namespace SpartaDungeonBattle
         public Inventory()
         {
             ItemList = new List<Item>();
-            ItemList.Add(new Equipment("무쇠갑옷", 100, "무쇠로 만들어져 튼튼한 갑옷입니다.", 0, 5));
-            ItemList.Add(new Equipment("낡은 검", 100, "쉽게 볼 수 있는 낡은 검 입니다.", 2, 0));
+            // 임시방편으로 이쁘게 보이기 위하여, 아이템 이름을 작성하실땐 영문자기준으로 10칸을 채웠습니다.
+            ItemList.Add(new Equipment("무쇠갑옷  ", 100, "무쇠로 만들어져 튼튼한 갑옷입니다.", 0, 5));
+            ItemList.Add(new Equipment("낡은 검   ", 100, "쉽게 볼 수 있는 낡은 검 입니다.", 2, 0));
             ItemList.Add(Consumption.MakePotion());
         }
         public Inventory(List<Item> itemList) { ItemList = itemList; }

--- a/Item.cs
+++ b/Item.cs
@@ -60,7 +60,7 @@ namespace SpartaDungeonBattle
 
         public static Consumption MakePotion()
         {
-            Consumption potion = new Consumption("붉은 포션", 20, "HP를 20 회복시킵니다.", ItemTarget.ToCharacter);
+            Consumption potion = new Consumption("붉은 포션 ", 20, "HP를 20 회복시킵니다.", ItemTarget.ToCharacter);
             potion.ItemToCharacter += (Character character) => { character.HP += 20; if (character.HP > character.MaxHP) character.HP = character.MaxHP; };
             return potion;
         }

--- a/StateManager.cs
+++ b/StateManager.cs
@@ -120,7 +120,7 @@ public static class StateManager
         Console.WriteLine("[인벤토리]");
         Console.WriteLine("보유중인 장비,포션을 관리할 수 있습니다.\n");
         Console.WriteLine("[아이템 목록]");
-        Console.WriteLine("    아이템 이름          효과                     설명               ");
+        Console.WriteLine("\n***아이템 이름  >>  능력치  >>  아이템 설명***\n");
         for (int i = 0; i < Character.CurrentCharacter.Inventory.Count; i++)
         {
             Item item = Character.CurrentCharacter.Inventory[i];
@@ -128,12 +128,15 @@ public static class StateManager
             {
                 case ItemType.CONSUMPTION :
                     Consumption consumption = item as Consumption;
-                    Console.WriteLine(" " + consumption.ItemName.PadRight(10, ' ') + "  |  " + consumption.Description);
+                    Console.WriteLine("    " + consumption.ItemName + "  >>  " + consumption.Description);
                     break;
                 case ItemType.EQUIPMENT :
                     Equipment equipment = item as Equipment;
-                    Console.WriteLine(" " + equipment.ItemName.PadRight(10, ' ') + "  |  공격력 : "+ equipment.Attack.ToString().PadRight(5, ' ') 
-                                        +"  방어력 : " + equipment.Defense.ToString().PadRight(5, ' ') + "  |  " + item.Description);
+                    Console.Write(equipment.OnEquipped ? "[E] " : "    ");
+                    Console.Write(equipment.ItemName);
+                    if (equipment.Attack > 0) Console.Write("  >>  공격력 : " + equipment.Attack.ToString().PadRight(3, ' '));
+                    if (equipment.Defense> 0) Console.Write("  >>  방어력 : " + equipment.Defense.ToString().PadRight(3, ' '));
+                    Console.WriteLine("  >>  " + item.Description);
                     break;
                 default:
                     break;


### PR DESCRIPTION
인벤토리창 출력하는 UI를 장착관리와 일치시킴
한글과 영문의 간격이 이상하게 표시되던것
임시방편으로 수정